### PR TITLE
HDA-3736 android-style-guide 저장소 최신화 - Kotlin, 함수 이름

### DIFF
--- a/Kotlin.md
+++ b/Kotlin.md
@@ -1,0 +1,48 @@
+# Kotlin
+## 비교
+- Boolean의 경우 `if (a?.b?.isTraded ?: false)` 보다는 `if (a?.b?.isTraded == true)` 와 같은 방식으로 구현한다.
+
+## Custom accessor VS Function
+- 행동을 나타내는 개념이면 function
+- 상태나 값등 정보를 가져오는 개념이면 custom accessor
+
+> [Kotlin: should I define Function or Property?](https://blog.kotlin-academy.com/kotlin-should-i-define-function-or-property-6786951da909)
+
+## 개행
+- 생성자, 함수에서 Parameter를 정의할때 한줄로 정의 가능하면 한줄, 그렇지 않으면 각 parameter별로 개행한다.
+
+### LiveData
+- xml에서 클릭시 사용되는 LiveData의 변수명은 xxxEvent로 선언: [Google blueprint 코드 참고](https://github.com/android/architecture-samples/blob/272cd63c8e6e37eecc0398a19415f7c4dc6950d5/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt#L60)
+
+## Statement
+### when
+- 한 줄에 들어가는 when 분기는 중괄호를 사용하지 않는다.
+```kotlin
+when (value) {
+	0 -> return
+	// ...
+}
+```
+
+- 여러개의 조건을 동시에 사용하는 경우 `->`를 포함한 블록은 내려서 작성한다.
+```kotlin
+when (value) {
+	foo -> // ...
+	bar,
+	baz
+	-> return
+}
+```
+
+- when statement를 enum class 또는 sealed class와 함께 쓰는 경우에는 `exhaustive` 확장 변수를 통해 강제로 when expression으로 변경하여 사용한다.
+```kotlin
+enum class Color {
+    RED, BLUE, GREEN
+}
+
+when (color) {
+    RED -> // ...
+    BLUE -> // ...
+    GREEN -> // ...
+}.exhaustive
+```

--- a/Kotlin.md
+++ b/Kotlin.md
@@ -67,17 +67,17 @@ getBrandList()   // X
 - 한 줄에 들어가는 when 분기는 중괄호를 사용하지 않는다.
 ```kotlin
 when (value) {
-	0 -> return
-	// ...
+    0 -> return
+    // ...
 }
 ```
 
 - 여러개의 조건을 동시에 사용하는 경우 `->`를 포함한 블록은 내려서 작성한다.
 ```kotlin
 when (value) {
-	foo -> // ...
-	bar,
-	baz
-	-> return
+    foo -> // ...
+    bar,
+    baz
+    -> return
 }
 ```

--- a/Kotlin.md
+++ b/Kotlin.md
@@ -46,3 +46,35 @@ when (color) {
     GREEN -> // ...
 }.exhaustive
 ```
+
+## 함수 이름
+- ViewModel을 observe()할때 모아놓는 함수 이름
+```kotlin
+setupXXX()
+```
+
+- 서버에서 데이터를 불러올때 함수 이름
+```kotlin
+fetchXXX()
+```
+
+- 서버에 저장할때 함수 이름
+```kotlin
+saveXXX()
+```
+
+- Return이 있는 데이터를 불러올때 함수 이름
+```kotlin
+getXXX()
+```
+
+- 특정 객체를 찾는 함수이름
+```
+findXXX()
+```
+
+- 복수형을 가져올때는 뒤에 s를 붙인다
+```kotlin
+getBrands()      // O
+getBrandList()   // X
+```

--- a/Kotlin.md
+++ b/Kotlin.md
@@ -23,6 +23,10 @@ when (color) {
 }.exhaustive
 ```
 
+> [Exhaustive when statement (공식 지원)](https://kotlinlang.org/docs/whatsnew1530.html#exhaustive-when-statements-for-sealed-and-boolean-subjects)
+> 
+> [Exhaustive plugin & 대안](https://github.com/cashapp/exhaustive#alternatives-considered)
+
 ## Naming Rules
 ### LiveData
 - xml에서 클릭시 사용되는 LiveData의 변수명은 xxxEvent로 선언: [Google blueprint 코드 참고](https://github.com/android/architecture-samples/blob/272cd63c8e6e37eecc0398a19415f7c4dc6950d5/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt#L60)

--- a/Kotlin.md
+++ b/Kotlin.md
@@ -1,40 +1,16 @@
 # Kotlin
-## 비교
+## Concepts
+### 비교
 - Boolean의 경우 `if (a?.b?.isTraded ?: false)` 보다는 `if (a?.b?.isTraded == true)` 와 같은 방식으로 구현한다.
 
-## Custom accessor VS Function
+### Custom accessor VS Function
 - 행동을 나타내는 개념이면 function
 - 상태나 값등 정보를 가져오는 개념이면 custom accessor
 
 > [Kotlin: should I define Function or Property?](https://blog.kotlin-academy.com/kotlin-should-i-define-function-or-property-6786951da909)
 
-## 개행
-- 생성자, 함수에서 Parameter를 정의할때 한줄로 정의 가능하면 한줄, 그렇지 않으면 각 parameter별로 개행한다.
-
-### LiveData
-- xml에서 클릭시 사용되는 LiveData의 변수명은 xxxEvent로 선언: [Google blueprint 코드 참고](https://github.com/android/architecture-samples/blob/272cd63c8e6e37eecc0398a19415f7c4dc6950d5/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt#L60)
-
-## Statement
-### when
-- 한 줄에 들어가는 when 분기는 중괄호를 사용하지 않는다.
-```kotlin
-when (value) {
-	0 -> return
-	// ...
-}
-```
-
-- 여러개의 조건을 동시에 사용하는 경우 `->`를 포함한 블록은 내려서 작성한다.
-```kotlin
-when (value) {
-	foo -> // ...
-	bar,
-	baz
-	-> return
-}
-```
-
-- when statement를 enum class 또는 sealed class와 함께 쓰는 경우에는 `exhaustive` 확장 변수를 통해 강제로 when expression으로 변경하여 사용한다.
+### Exhaustive when statement
+when statement를 enum class 또는 sealed class와 함께 쓰는 경우에는 `exhaustive` 확장 변수를 통해 강제로 when expression으로 변경하여 사용한다.
 ```kotlin
 enum class Color {
     RED, BLUE, GREEN
@@ -47,7 +23,11 @@ when (color) {
 }.exhaustive
 ```
 
-## 함수 이름
+## Naming Rules
+### LiveData
+- xml에서 클릭시 사용되는 LiveData의 변수명은 xxxEvent로 선언: [Google blueprint 코드 참고](https://github.com/android/architecture-samples/blob/272cd63c8e6e37eecc0398a19415f7c4dc6950d5/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt#L60)
+
+### 함수 이름
 - ViewModel을 observe()할때 모아놓는 함수 이름
 ```kotlin
 setupXXX()
@@ -77,4 +57,27 @@ findXXX()
 ```kotlin
 getBrands()      // O
 getBrandList()   // X
+```
+
+## Formatting
+### 개행
+- 생성자, 함수에서 Parameter를 정의할때 한줄로 정의 가능하면 한줄, 그렇지 않으면 각 parameter별로 개행한다.
+
+### When Statement
+- 한 줄에 들어가는 when 분기는 중괄호를 사용하지 않는다.
+```kotlin
+when (value) {
+	0 -> return
+	// ...
+}
+```
+
+- 여러개의 조건을 동시에 사용하는 경우 `->`를 포함한 블록은 내려서 작성한다.
+```kotlin
+when (value) {
+	foo -> // ...
+	bar,
+	baz
+	-> return
+}
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # 목록
 각 항목별 가이드는 아래에서 확인해볼 수 있으며 계속 유지보수되어 추가될 예정입니다.
 - [Java](Java.md)
+- [Kotlin](Kotlin.md)
 - [Resource](Resource.md)
 - [Gradle](Gradle.md)
 - [Architecture](Architecture.md)


### PR DESCRIPTION
큰 수정없이 Notion에는 있고 GitHub 저장소에는 없는 부분들만 추가했습니다.
[LiveData](https://github.com/PRNDcompany/android-style-guide/compare/feature/HDA-3736-kotlin?expand=1#diff-3eebeb56d43f39aa213cee6518444f35ac55ec99ce761ee8caa18df117600dc1R14)와 같이 레거시 코드에만 해당되고 앞으로는 더 이상 쓰이지 않는 컨벤션들도 일단은 남겨두었습니다.

추가로 **함수 이름** 문서는 별도로 분리할 필요없이 Kotlin 문서에 추가되면 좋을 것 같아 두 문서를 합쳤습니다.